### PR TITLE
[AR-2557] bug hook set on disconnect event is not called

### DIFF
--- a/src/pages/homePage.vue
+++ b/src/pages/homePage.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { Connection } from 'penpal'
 import { toRefs, onMounted } from 'vue'
-import { useRouter } from 'vue-router'
+import { useRouter, onBeforeRouteLeave } from 'vue-router'
 import { useToast } from 'vue-toastification'
 
 import type { ParentConnectionApi } from '@/models/Connection'
@@ -97,6 +97,10 @@ async function handleLogout() {
 function onCloseClick() {
   router.push('/signMessage')
 }
+
+onBeforeRouteLeave((to) => {
+  if (to.path.includes('login')) parentConnection?.destroy()
+})
 </script>
 
 <template>


### PR DESCRIPTION
1. Used `onBeforeRouteLeave` navigation guard to check if the routing is to `/login` and destroy the connection.