### PR TITLE
[AR-3194] - replace wallet with auth sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "arcana-wallet",
       "version": "0.1.0",
       "dependencies": {
-        "@arcana/auth-core": "^0.0.3-beta1",
-        "@arcana/wallet": "^0.0.7-beta1",
+        "@arcana/auth": "^0.0.9-beta9",
+        "@arcana/auth-core": "^0.0.3-beta2",
         "@ethereumjs/tx": "^3.4.0",
         "assert": "^2.0.0",
         "buffer": "^6.0.3",
@@ -87,34 +87,10 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@arcana/auth-core": {
-      "version": "0.0.3-beta1",
-      "resolved": "https://registry.npmjs.org/@arcana/auth-core/-/auth-core-0.0.3-beta1.tgz",
-      "integrity": "sha512-bcME56OF2cLi2zmphBqe05sUoUCAeA3dJ3G6P87gNqIdmipjvmzRv79iWwuGq8v2UZcVjmS3zApQtUvsoR2TKQ==",
-      "dependencies": {
-        "@arcana/keystore": "^0.0.7-beta",
-        "@stablelib/base64": "^1.0.1",
-        "ethers": "^5.5.1"
-      }
-    },
-    "node_modules/@arcana/keystore": {
-      "version": "0.0.7-beta",
-      "resolved": "https://registry.npmjs.org/@arcana/keystore/-/keystore-0.0.7-beta.tgz",
-      "integrity": "sha512-gbYUNHvE26EWl8IWXVRn+xxqCPZSlGPshbzmOFRMPN4U2wJtj6oGRt27OytDS4r9xlzltRJV7ZTkXmofvzgPdw==",
-      "dependencies": {
-        "@sentry/browser": "^6.13.3",
-        "@sentry/tracing": "^6.13.3",
-        "bn.js": "^5.2.0",
-        "eccrypto": "^1.1.6",
-        "elliptic": "^6.5.4",
-        "ethers": "^5.4.5",
-        "web3-utils": "^1.5.2"
-      }
-    },
-    "node_modules/@arcana/wallet": {
-      "version": "0.0.7-beta1",
-      "resolved": "https://registry.npmjs.org/@arcana/wallet/-/wallet-0.0.7-beta1.tgz",
-      "integrity": "sha512-INxOFUgUM+nKE8WhgkezcULglYFPO6r8WO6sZkWG02/bvSU7eYaHIkDq7Y3FwCCYD1v2o5KbBCAIYohf5cGu0A==",
+    "node_modules/@arcana/auth": {
+      "version": "0.0.9-beta9",
+      "resolved": "https://registry.npmjs.org/@arcana/auth/-/auth-0.0.9-beta9.tgz",
+      "integrity": "sha512-SESwmn8CIq2f238v7My92jyfVFW9VYiuU0PtMr1xIYEwQpFQCqjPe+bDJJK/1FC4oo2mEfwIgDl2xEydk3A0xQ==",
       "dependencies": {
         "@metamask/safe-event-emitter": "^2.0.0",
         "@sentry/browser": "^6.19.7",
@@ -133,6 +109,30 @@
         "process": "^0.11.10",
         "stream-browserify": "^3.0.0",
         "web3-providers-http": "^1.6.1"
+      }
+    },
+    "node_modules/@arcana/auth-core": {
+      "version": "0.0.3-beta2",
+      "resolved": "https://registry.npmjs.org/@arcana/auth-core/-/auth-core-0.0.3-beta2.tgz",
+      "integrity": "sha512-Ts4gyFAwepbPj6LnBO801LMDgPCQQKLeoK/ZyamQS52Rm4qX2+dpKgucfZL9A/BIWdautZQAbfp2LFCdbAAWvA==",
+      "dependencies": {
+        "@arcana/keystore": "^0.0.7-beta",
+        "@stablelib/base64": "^1.0.1",
+        "ethers": "^5.5.1"
+      }
+    },
+    "node_modules/@arcana/keystore": {
+      "version": "0.0.7-beta",
+      "resolved": "https://registry.npmjs.org/@arcana/keystore/-/keystore-0.0.7-beta.tgz",
+      "integrity": "sha512-gbYUNHvE26EWl8IWXVRn+xxqCPZSlGPshbzmOFRMPN4U2wJtj6oGRt27OytDS4r9xlzltRJV7ZTkXmofvzgPdw==",
+      "dependencies": {
+        "@sentry/browser": "^6.13.3",
+        "@sentry/tracing": "^6.13.3",
+        "bn.js": "^5.2.0",
+        "eccrypto": "^1.1.6",
+        "elliptic": "^6.5.4",
+        "ethers": "^5.4.5",
+        "web3-utils": "^1.5.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -19242,34 +19242,10 @@
         "@jridgewell/trace-mapping": "^0.3.9"
       }
     },
-    "@arcana/auth-core": {
-      "version": "0.0.3-beta1",
-      "resolved": "https://registry.npmjs.org/@arcana/auth-core/-/auth-core-0.0.3-beta1.tgz",
-      "integrity": "sha512-bcME56OF2cLi2zmphBqe05sUoUCAeA3dJ3G6P87gNqIdmipjvmzRv79iWwuGq8v2UZcVjmS3zApQtUvsoR2TKQ==",
-      "requires": {
-        "@arcana/keystore": "^0.0.7-beta",
-        "@stablelib/base64": "^1.0.1",
-        "ethers": "^5.5.1"
-      }
-    },
-    "@arcana/keystore": {
-      "version": "0.0.7-beta",
-      "resolved": "https://registry.npmjs.org/@arcana/keystore/-/keystore-0.0.7-beta.tgz",
-      "integrity": "sha512-gbYUNHvE26EWl8IWXVRn+xxqCPZSlGPshbzmOFRMPN4U2wJtj6oGRt27OytDS4r9xlzltRJV7ZTkXmofvzgPdw==",
-      "requires": {
-        "@sentry/browser": "^6.13.3",
-        "@sentry/tracing": "^6.13.3",
-        "bn.js": "^5.2.0",
-        "eccrypto": "^1.1.6",
-        "elliptic": "^6.5.4",
-        "ethers": "^5.4.5",
-        "web3-utils": "^1.5.2"
-      }
-    },
-    "@arcana/wallet": {
-      "version": "0.0.7-beta1",
-      "resolved": "https://registry.npmjs.org/@arcana/wallet/-/wallet-0.0.7-beta1.tgz",
-      "integrity": "sha512-INxOFUgUM+nKE8WhgkezcULglYFPO6r8WO6sZkWG02/bvSU7eYaHIkDq7Y3FwCCYD1v2o5KbBCAIYohf5cGu0A==",
+    "@arcana/auth": {
+      "version": "0.0.9-beta9",
+      "resolved": "https://registry.npmjs.org/@arcana/auth/-/auth-0.0.9-beta9.tgz",
+      "integrity": "sha512-SESwmn8CIq2f238v7My92jyfVFW9VYiuU0PtMr1xIYEwQpFQCqjPe+bDJJK/1FC4oo2mEfwIgDl2xEydk3A0xQ==",
       "requires": {
         "@metamask/safe-event-emitter": "^2.0.0",
         "@sentry/browser": "^6.19.7",
@@ -19288,6 +19264,30 @@
         "process": "^0.11.10",
         "stream-browserify": "^3.0.0",
         "web3-providers-http": "^1.6.1"
+      }
+    },
+    "@arcana/auth-core": {
+      "version": "0.0.3-beta2",
+      "resolved": "https://registry.npmjs.org/@arcana/auth-core/-/auth-core-0.0.3-beta2.tgz",
+      "integrity": "sha512-Ts4gyFAwepbPj6LnBO801LMDgPCQQKLeoK/ZyamQS52Rm4qX2+dpKgucfZL9A/BIWdautZQAbfp2LFCdbAAWvA==",
+      "requires": {
+        "@arcana/keystore": "^0.0.7-beta",
+        "@stablelib/base64": "^1.0.1",
+        "ethers": "^5.5.1"
+      }
+    },
+    "@arcana/keystore": {
+      "version": "0.0.7-beta",
+      "resolved": "https://registry.npmjs.org/@arcana/keystore/-/keystore-0.0.7-beta.tgz",
+      "integrity": "sha512-gbYUNHvE26EWl8IWXVRn+xxqCPZSlGPshbzmOFRMPN4U2wJtj6oGRt27OytDS4r9xlzltRJV7ZTkXmofvzgPdw==",
+      "requires": {
+        "@sentry/browser": "^6.13.3",
+        "@sentry/tracing": "^6.13.3",
+        "bn.js": "^5.2.0",
+        "eccrypto": "^1.1.6",
+        "elliptic": "^6.5.4",
+        "ethers": "^5.4.5",
+        "web3-utils": "^1.5.2"
       }
     },
     "@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@arcana/auth-core": "^0.0.3-beta2",
-    "@arcana/wallet": "^0.0.7-beta1",
+    "@arcana/auth": "^0.0.9-beta9",
     "@ethereumjs/tx": "^3.4.0",
     "assert": "^2.0.0",
     "buffer": "^6.0.3",

--- a/src/models/Connection.ts
+++ b/src/models/Connection.ts
@@ -1,4 +1,4 @@
-import { IAppConfig, AppMode } from '@arcana/wallet'
+import { AppConfig, AppMode } from '@arcana/auth'
 
 type RequestMethod =
   | 'eth_sign'
@@ -48,7 +48,7 @@ type RedirectParentConnectionApi = {
 }
 
 type ParentConnectionApi = {
-  getAppConfig(): IAppConfig
+  getAppConfig(): AppConfig
   onMethodResponse(method: RequestMethod, response: Response): void
   sendPendingRequestCount(count: number): void
   getParentUrl(): string

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -1,4 +1,4 @@
-import { AppMode } from '@arcana/wallet'
+import { AppMode } from '@arcana/auth'
 import { defineStore } from 'pinia'
 
 import type { Theme } from '@/models/Theme'

--- a/src/utils/getValidAppMode.ts
+++ b/src/utils/getValidAppMode.ts
@@ -1,4 +1,4 @@
-import { AppMode } from '@arcana/wallet'
+import { AppMode } from '@arcana/auth'
 
 enum WalletType {
   NoUI = 0,


### PR DESCRIPTION
Replace Wallet SDK with latest(`0.0.9-beta9`) Auth SDK 