### PR TITLE
[AR-3828] Logout promise not being resolved

### DIFF
--- a/src/pages/homePage.vue
+++ b/src/pages/homePage.vue
@@ -97,7 +97,9 @@ async function handleLogout() {
   const authProvider = await getAuthProvider(appId)
   await user.handleLogout(authProvider)
   parentConnectionInstance?.onEvent('disconnect')
-  router.push(`/${appId}/login`)
+  setTimeout(() => {
+    router.push(`/${appId}/login`)
+  })
 }
 
 function onCloseClick() {


### PR DESCRIPTION
Resolves [AR-3828](https://team-1624093970686.atlassian.net/browse/AR-3828)

### Issue
In `logout` function the routing happens before the reply is sent back, so connection gets destroyed and reply cannot be sent which in turn causes the `logout` promise to not resolve in `auth` SDK.

### Resolution
Wrapping the routing in `setTimeout` with no 0 delay causes it to be processed in the next event cycle and the logout promise resolves successfully before routing and before connection being destroyed.