### PR TITLE
[AR-4067] Updated `getAvailableLogin` function

### DIFF
--- a/src/pages/signIn.vue
+++ b/src/pages/signIn.vue
@@ -43,7 +43,7 @@ const penpalMethods = {
   isLoginAvailable: (kind: SocialLoginType) =>
     availableLogins.value.includes(kind),
   getPublicKey: handleGetPublicKey,
-  getAvailableLogins: () => availableLogins.value,
+  getAvailableLogins: () => [...availableLogins.value],
 }
 
 const cleanup = () => {


### PR DESCRIPTION
- Directly sending `availableLogins.value` throws an error since its a ref.
- Using spread operator to create new array from the ref value