### PR TITLE
[AR-4323] Pass RPC url to account handler

### DIFF
--- a/src/components/SendTokens.vue
+++ b/src/components/SendTokens.vue
@@ -80,7 +80,10 @@ async function handleSendToken() {
       gasPrice: ethers.utils.parseEther(`${gasFeeInGwei.value}`).toHexString(),
       from: userStore.walletAddress,
     }
-    const accountHandler = new AccountHandler(userStore.privateKey)
+    const accountHandler = new AccountHandler(
+      userStore.privateKey,
+      rpcStore.rpcConfig?.rpcUrls[0]
+    )
     await accountHandler.requestSendTransaction(payload)
     toast.success('Tokens sent Successfully')
   } catch (err: object) {


### PR DESCRIPTION
Diagnosis: While initiating account handler, the RPC url was not passed as param.

Solution: Passed the RPC url from Pinia Store.