### PR TITLE
AR-4524 Bug fix - When network is changed, validAppMode was throwing error in console

### DIFF
--- a/src/pages/homeScreen.vue
+++ b/src/pages/homeScreen.vue
@@ -124,21 +124,21 @@ async function initAccountHandler() {
 
     accountHandler = new AccountHandler(userStore.privateKey)
 
-    const account = accountHandler.getAccount()
-    userStore.setWalletAddress(account.address)
+    if (!userStore.walletAddress) {
+      const account = accountHandler.getAccount()
+      userStore.setWalletAddress(account.address)
+    }
 
-    const walletType = await getWalletType(
-      appStore.id,
-      rpcStore.selectedRpcConfig.rpcUrls[0]
-    )
+    if (typeof appStore.validAppMode !== 'number') {
+      const walletType = await getWalletType(appStore.id)
+      setAppMode(walletType, parentConnectionInstance)
+    }
 
     const keeper = new RequestHandler(accountHandler)
     keeper.setConnection(parentConnection)
     await keeper.setRpcConfig(rpcStore.selectedRpcConfig)
 
     watchRequestQueue(requestStore, keeper)
-
-    setAppMode(walletType, parentConnectionInstance)
 
     const chainId = await accountHandler.getChainId()
     parentConnectionInstance.onEvent('connect', { chainId })


### PR DESCRIPTION
## Changes

- Removed rpcUrl while fetching validAppMode so it uses default Arcana's rpcUrl instead. (Since appMode is stored in Arcana's chain, it was returning undefined if we fetched it from rpc of other chains)
- Added 2 checks
  - If wallet address is already present in store then don't update it since wallet address remains same for all chains.
  - If appMode is already present in store (if it's a number), then don't update it, since appMode can't be changed once it is set.