### PR TITLE
Set Chain-Id as string while switch chain

### DIFF
--- a/src/utils/requestManagement.ts
+++ b/src/utils/requestManagement.ts
@@ -46,7 +46,7 @@ function getEtherInvalidParamsError(msg) {
 
 function switchChain(request, keeper) {
   const { chainId } = request.params[0]
-  rpcStore.setSelectedChainId(parseInt(chainId))
+  rpcStore.setSelectedChainId(`${parseInt(chainId)}`)
   keeper.reply(request.method, {
     result: `Chain changed to ${rpcStore.selectedRpcConfig.chainName}`,
     id: request.id,


### PR DESCRIPTION
Issue: Build fails because the chain id is set as `number` while switching chain.

Fix: set it as `string`.