### PR TITLE
Convert string to number to get proper hex

### DIFF
--- a/src/utils/requestHandler.ts
+++ b/src/utils/requestHandler.ts
@@ -139,8 +139,8 @@ class RequestHandler {
     return engine
   }
 
-  private getNetAndChainMiddleware(chainId: number) {
-    const hexChainId = getHexFromNumber(chainId)
+  private getNetAndChainMiddleware(chainId: number | string) {
+    const hexChainId = getHexFromNumber(Number(chainId))
     return createScaffoldMiddleware({
       eth_chainId: hexChainId,
       net_version: chainId,
@@ -149,7 +149,7 @@ class RequestHandler {
 }
 
 const getHexFromNumber = (n: number, prefix = true): string => {
-  const h = Number(n).toString(16)
+  const h = n.toString(16)
   return prefix ? addHexPrefix(h) : removeHexPrefix(h)
 }
 


### PR DESCRIPTION
Resolves: https://team-1624093970686.atlassian.net/browse/AR-4862

Converted string to number so it returns proper hex string in eth_chainId

Previously `40404` was returning `40404`
Now it'll return `9dd4`