### PR TITLE
[AR-4871] Fix for edit network issue

### DIFF
--- a/src/components/EditNetwork.vue
+++ b/src/components/EditNetwork.vue
@@ -55,6 +55,7 @@ function handleSubmit() {
       blockExplorerUrls: [rpcConfig.value.explorerUrl],
       rpcUrls: [rpcConfig.value.rpcUrl],
       favicon: rpcConfigForEdit?.favicon,
+      isCustom: true,
       nativeCurrency: {
         symbol: rpcConfig.value.currencySymbol,
         decimals: 18,


### PR DESCRIPTION
Issue: Couldn't edit after first edit of custom network.

Fix: Set `isCustom` prop to `true` in the edit network payload.