### PR TITLE
Move popup close logic after request is processed

### DIFF
--- a/src/utils/requestManagement.ts
+++ b/src/utils/requestManagement.ts
@@ -36,9 +36,6 @@ async function watchRequestQueue(keeper) {
       const pendingRequestCount = Object.values(pendingRequests).length
       const connectionInstance = await keeper.connection.promise
       const appMode = await connectionInstance.getAppMode()
-      if (appMode === AppMode.Widget && pendingRequestCount === 0) {
-        connectionInstance.closePopup()
-      }
       try {
         connectionInstance.sendPendingRequestCount(pendingRequestCount)
       } catch (err) {
@@ -47,6 +44,9 @@ async function watchRequestQueue(keeper) {
       if (processQueue.length > 0) {
         const request = processQueue.shift()
         if (request) processRequest(request, keeper)
+        if (appMode === AppMode.Widget && pendingRequestCount === 0) {
+          connectionInstance.closePopup()
+        }
         try {
           connectionInstance.sendPendingRequestCount(pendingRequestCount)
         } catch (err) {


### PR DESCRIPTION
## Changes

In widget mode/partial ui mode, popup was autoclosing even before request was being processed. Moved the logic to close popup only if any action has been taken (Either approve or reject)

## Checklist

- [ ] The branch name follows the format: `developer/AR-XXX-issue-name`.
- [x] The changes have been tested locally.
