### PR TITLE
Added types and permission value for eth_requestAccounts

### DIFF
--- a/src/models/Connection.ts
+++ b/src/models/Connection.ts
@@ -10,6 +10,7 @@ type RequestMethod =
   | 'eth_signTransaction'
   | 'eth_sendTransaction'
   | 'eth_accounts'
+  | 'eth_requestAccounts'
   | 'eth_getEncryptionPublicKey'
   | 'wallet_addEthereumChain'
   | 'wallet_switchEthereumChain'
@@ -22,6 +23,7 @@ const PERMISSIONS: Record<RequestMethod, boolean> = Object.freeze({
   eth_signTransaction: true,
   eth_sendTransaction: true,
   eth_accounts: false,
+  eth_requestAccounts: false,
   eth_getEncryptionPublicKey: false,
   wallet_addEthereumChain: true,
   wallet_switchEthereumChain: true,


### PR DESCRIPTION
Resolves [AR-4864](https://team-1624093970686.atlassian.net/browse/AR-4864).

## Changes

- `eth_requestAccounts` was already there as a part of json-rpc-engine in wallet [here](https://github.com/arcana-network/wallet-ui/blob/dev/src/utils/walletMiddleware.ts#L83)
- Added types and permission value for `eth_requestAccounts`

## Screencasts
[Screencast from 2022-12-22 08-47-55.webm](https://user-images.githubusercontent.com/24249988/209048187-6aed947f-67ea-405c-bbb1-cfad7323fa50.webm)

## Checklist

- [x] The branch name follows the format: `developer/AR-XXX-issue-name`.
- [x] The changes have been tested locally.
