### PR TITLE
Change default chain id

### DIFF
--- a/src/models/RpcConfigList.ts
+++ b/src/models/RpcConfigList.ts
@@ -55,14 +55,6 @@ const CHAIN_LIST = [
     },
   },
   {
-    chainId: '40405',
-    rpcUrls: ['https://blockchain001-testnet.arcana.network'],
-    chainName: 'Arcana (Testnet)',
-    blockExplorerUrls: ['https://explorer.beta.arcana.network'],
-    favicon: 'arcana-icon',
-    isCustom: false,
-  },
-  {
     chainId: '11155111',
     rpcUrls: ['https://rpc.sepolia.org'],
     chainName: 'Sepolia (Testnet)',
@@ -76,19 +68,7 @@ const CHAIN_LIST = [
   },
 ]
 
-if (process.env.VUE_APP_ARCANA_AUTH_NETWORK === 'dev') {
-  CHAIN_LIST.push({
-    chainId: '40404',
-    rpcUrls: ['https://blockchain-dev.arcana.network'],
-    chainName: 'Arcana Dev',
-    blockExplorerUrls: ['https://explorer.dev.arcana.network'],
-    favicon: 'arcana-icon',
-    isCustom: false,
-  })
-}
-
-const DEFAULT_CHAIN_ID =
-  process.env.VUE_APP_ARCANA_AUTH_NETWORK === 'dev' ? '40404' : '40405'
+const DEFAULT_CHAIN_ID = '1'
 
 export type { RpcConfigWallet }
 export { CHAIN_LIST, DEFAULT_CHAIN_ID }

--- a/src/pages/loggedInView.vue
+++ b/src/pages/loggedInView.vue
@@ -81,7 +81,6 @@ async function initAccountHandler() {
       const requestHandler = getRequestHandler()
       if (requestHandler) {
         requestHandler.setConnection(parentConnection)
-
         const { chainId, ...rpcConfig } = rpcStore.selectedRpcConfig
         const selectedChainId = Number(chainId)
         await requestHandler.setRpcConfig({
@@ -168,7 +167,10 @@ async function getRpcConfig() {
   try {
     if (parentConnection) {
       const parentConnectionInstance = await parentConnection.promise
-      const rpcConfig = await parentConnectionInstance.getRpcConfig()
+      let rpcConfig = await parentConnectionInstance.getRpcConfig()
+      if ([40404, 40405].includes(Number(rpcConfig.chainId))) {
+        rpcConfig = CHAIN_LIST[0]
+      }
       rpcStore.setSelectedChainId(`${parseInt(rpcConfig.chainId)}`)
     }
   } catch (err) {


### PR DESCRIPTION
## Changes

- Removed Arcana related config
- Kept a check for chain Id 40405 and 40404 for now since Dashboard uses old auth sdk which still sends these as default chain, if these are sent automatically convert it to Ethereum mainnet config since these chains are owned by Arcana

## Checklist

- [x] The branch name follows the format: `developer/AR-XXX-issue-name`.
- [x] The changes have been tested locally.
