### PR TITLE
Remove getAppAddress function as it is deprecated

### DIFF
--- a/src/utils/getwalletType.ts
+++ b/src/utils/getwalletType.ts
@@ -9,18 +9,11 @@ const getContract = (rpcUrl, appAddress) => {
   )
 }
 
-const getAppAddress = async (id) => {
-  const addressResponse = await fetch(
-    `${process.env.VUE_APP_WALLET_GATEWAY}/get-address/?id=${id}`
-  )
-  return (await addressResponse.json()).address
-}
-
 export const getWalletType = async (
   appId,
   rpcUrl = process.env.VUE_APP_WALLET_RPC_URL
 ) => {
-  const appAddress = await getAppAddress(appId)
+  const appAddress = appId
   if (!appAddress) {
     return null
   }


### PR DESCRIPTION
## Changes

- Remove getAppAddress function as it is deprecated

## Checklist

- [ ] The branch name follows the format: `developer/AR-XXX-issue-name`.
- [x] The changes have been tested locally.
