### PR TITLE
Use Fontsource instead of Google Fonts for fonts

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -11,6 +11,6 @@
       font-src 'self' fonts.gstatic.com gstatic.com *.gstatic.com;
       img-src 'self' data:;
       script-src 'self' 'unsafe-inline' https://*.cloudfront.net *.google-analytics.com *.googletagmanager.com;
-      style-src 'self' 'unsafe-inline' https://*.cloudfront.net https://fonts.googleapis.com;
+      style-src 'self' 'unsafe-inline' https://*.cloudfront.net;
       frame-src *.arcana.network *.transak.com *.ramp.network;
     '''

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,8 @@
         "@arcana/auth-core": "^1.0.0-beta.5",
         "@arcana/key-helper": "^1.0.0-beta.2",
         "@ethereumjs/tx": "^3.4.0",
+        "@fontsource/montserrat": "^4.5.14",
+        "@fontsource/sora": "^4.5.12",
         "@headlessui/vue": "^1.7.2",
         "@ramp-network/ramp-instant-sdk": "^4.0.1",
         "@sentry/tracing": "^7.5.1",
@@ -2669,6 +2671,16 @@
         "@ethersproject/properties": "^5.7.0",
         "@ethersproject/strings": "^5.7.0"
       }
+    },
+    "node_modules/@fontsource/montserrat": {
+      "version": "4.5.14",
+      "resolved": "https://registry.npmjs.org/@fontsource/montserrat/-/montserrat-4.5.14.tgz",
+      "integrity": "sha512-fTvrteVzuFUePhr4QYBGoK8G/YHLJ3IhF1HhKg0AxcFvZajJT7rM7ULdmKLSd2PkX44R3aaFZq1zDbmjbGGI+w=="
+    },
+    "node_modules/@fontsource/sora": {
+      "version": "4.5.12",
+      "resolved": "https://registry.npmjs.org/@fontsource/sora/-/sora-4.5.12.tgz",
+      "integrity": "sha512-7pWwrWIKcLH0pvKCSssb96KFFKwt5+eKHC4yHfFYtxapQ6Ax+/Rj02QHnIkXyy5nc5cOvyOAQM2MAIGlMtoj9w=="
     },
     "node_modules/@gar/promisify": {
       "version": "1.1.3",
@@ -20555,6 +20567,16 @@
         "@ethersproject/properties": "^5.7.0",
         "@ethersproject/strings": "^5.7.0"
       }
+    },
+    "@fontsource/montserrat": {
+      "version": "4.5.14",
+      "resolved": "https://registry.npmjs.org/@fontsource/montserrat/-/montserrat-4.5.14.tgz",
+      "integrity": "sha512-fTvrteVzuFUePhr4QYBGoK8G/YHLJ3IhF1HhKg0AxcFvZajJT7rM7ULdmKLSd2PkX44R3aaFZq1zDbmjbGGI+w=="
+    },
+    "@fontsource/sora": {
+      "version": "4.5.12",
+      "resolved": "https://registry.npmjs.org/@fontsource/sora/-/sora-4.5.12.tgz",
+      "integrity": "sha512-7pWwrWIKcLH0pvKCSssb96KFFKwt5+eKHC4yHfFYtxapQ6Ax+/Rj02QHnIkXyy5nc5cOvyOAQM2MAIGlMtoj9w=="
     },
     "@gar/promisify": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "@arcana/auth-core": "^1.0.0-beta.5",
     "@arcana/key-helper": "^1.0.0-beta.2",
     "@ethereumjs/tx": "^3.4.0",
+    "@fontsource/montserrat": "^4.5.14",
+    "@fontsource/sora": "^4.5.12",
     "@headlessui/vue": "^1.7.2",
     "@ramp-network/ramp-instant-sdk": "^4.0.1",
     "@sentry/tracing": "^7.5.1",

--- a/src/App.vue
+++ b/src/App.vue
@@ -55,8 +55,6 @@ watch(showRequestPage, () => {
 </template>
 
 <style>
-@import url('https://fonts.googleapis.com/css2?family=Sora:wght@100;400;600;700&display=block');
-@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@500;600&display=block');
 @import '@/assets/css/reset.css';
 
 :root {
@@ -174,7 +172,7 @@ watch(showRequestPage, () => {
 
 body {
   height: 100vh;
-  font-family: Sora, sans-serif;
+  font-family: SoraVariable, sans-serif;
 }
 
 #app {
@@ -185,14 +183,14 @@ body {
 button {
   height: 40px;
 
-  /* TODO: Brainstrom on managing outlines. https://github.com/arcana-network/wallet-ui/pull/1#discussion_r824371816 */
+  /* TODO: Brainstorm on managing outlines. https://github.com/arcana-network/wallet-ui/pull/1#discussion_r824371816 */
   cursor: pointer;
   background: transparent;
   outline: none;
 }
 
 .font-montserrat {
-  font-family: Montserrat, sans-serif;
+  font-family: MontserratVariable, sans-serif;
 }
 
 .color-secondary {

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,8 @@ import App from '@/App.vue'
 import { router } from '@/routes/index'
 import { store } from '@/store'
 
+import '@fontsource/montserrat/variable.css'
+import '@fontsource/sora/variable.css'
 import 'vue-toastification/dist/index.css'
 
 const toastOptions = {


### PR DESCRIPTION
# Pull Request Template

Resolves [AR-5711](https://team-1624093970686.atlassian.net/browse/AR-5711).

## Blocking dependencies

None.

## Changes

Replaced Google Fonts with fontsource for fonts.

## Checklist

- [x] The branch name follows the format: `developer/AR-XXX-issue-name`.
- [x] The changes have been tested locally.


[AR-5711]: https://team-1624093970686.atlassian.net/browse/AR-5711?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ