### PR TITLE
Allow secure images to load with `https:`

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -9,7 +9,7 @@
     X-Content-Type-Options = "nosniff"
     Content-Security-Policy = '''
       font-src 'self' fonts.gstatic.com gstatic.com *.gstatic.com;
-      img-src 'self' data:;
+      img-src 'self' data: https:;
       script-src 'self' 'unsafe-inline' https://*.cloudfront.net *.google-analytics.com *.googletagmanager.com;
       style-src 'self' 'unsafe-inline' https://*.cloudfront.net https://fonts.googleapis.com;
       frame-src *.arcana.network *.transak.com *.ramp.network;


### PR DESCRIPTION
## Changes

- Allow secure images to load with `https:`

## Checklist

- [ ] The branch name follows the format: `developer/AR-XXX-issue-name`.
- [ ] The changes have been tested locally.
