### PR TITLE
[HOTFIX] Set mfa after setup and get mfa after login

### DIFF
--- a/src/pages/MFASetup.vue
+++ b/src/pages/MFASetup.vue
@@ -223,6 +223,8 @@ async function handlePinProceed() {
     }
     try {
       await createShare(pinToEncryptMFAShare.value)
+      const dkgShare = JSON.parse(storage.local.getItem('pk') as string)
+      storage.local.setItem(`${dkgShare.id}-has-mfa`, '1')
       storage.local.removeItem('pk')
     } catch (e) {
       // eslint-disable-next-line no-undef
@@ -238,7 +240,6 @@ async function handlePinProceed() {
 }
 
 async function handleDone() {
-  // eslint-disable-next-line no-undef
   // eslint-disable-next-line no-undef
   return connectionToParent.replyTo(process.env.VUE_APP_WALLET_DOMAIN)
 }

--- a/src/pages/loginRedirect.vue
+++ b/src/pages/loginRedirect.vue
@@ -40,7 +40,7 @@ async function init() {
     const authProvider = await getAuthProvider(`${appId}`)
     if (authProvider.isLoggedIn()) {
       const info = authProvider.getUserInfo()
-      const userInfo: GetInfoOutput = {
+      const userInfo: GetInfoOutput & { hasMfa?: boolean } = {
         userInfo: info.userInfo,
         loginType: info.loginType,
         privateKey: '',
@@ -60,6 +60,8 @@ async function init() {
       await core.init()
       const key = await core.getKey()
       userInfo.privateKey = key
+      userInfo.hasMfa =
+        storage.local.getItem(`${userInfo.userInfo.id}-has-mfa`) === '1'
       storage.session.setItem(`userInfo`, JSON.stringify(userInfo))
       storage.session.setItem(`isLoggedIn`, JSON.stringify(true))
       const messageId = getUniqueId()


### PR DESCRIPTION
## Changes

- Set mfa status in Verify page's wallet frame after MFA setup
- Get MFA status from local storage after login so it can be used to determine whether to show MFA setup message or not

## Checklist

- [ ] The branch name follows the format: `developer/AR-XXX-issue-name`.
- [x] The changes have been tested locally.
