### PR TITLE
Downgrade key-helper sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@arcana/auth": "^0.1.3",
         "@arcana/auth-core": "^1.0.0-beta.6",
-        "@arcana/key-helper": "^1.0.0-beta.6",
+        "@arcana/key-helper": "^1.0.0-beta.5",
         "@ethereumjs/tx": "^3.4.0",
         "@fontsource/montserrat": "^4.5.14",
         "@fontsource/sora": "^4.5.12",
@@ -147,9 +147,9 @@
       }
     },
     "node_modules/@arcana/key-helper": {
-      "version": "1.0.0-beta.6",
-      "resolved": "https://registry.npmjs.org/@arcana/key-helper/-/key-helper-1.0.0-beta.6.tgz",
-      "integrity": "sha512-kIAORzwYIRxx5dVNnNLl8tLbgZyYsbEdQTx5bdkMv1+kq7apvUT6Pi2K3c2dFgpiNrCza0ru975gcUhLDszmxQ==",
+      "version": "1.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@arcana/key-helper/-/key-helper-1.0.0-beta.5.tgz",
+      "integrity": "sha512-kYGOV6TXqc9P3p4yXRRRhXkBDx2DMSK1/Xgufl5vxLb0F2lo7dbV6irPllKxfAs9WYE9B1EHPwMciQQrnws9lg==",
       "dependencies": {
         "bn.js": "^5.2.1",
         "elliptic": "^6.5.4",
@@ -18927,9 +18927,9 @@
       }
     },
     "@arcana/key-helper": {
-      "version": "1.0.0-beta.6",
-      "resolved": "https://registry.npmjs.org/@arcana/key-helper/-/key-helper-1.0.0-beta.6.tgz",
-      "integrity": "sha512-kIAORzwYIRxx5dVNnNLl8tLbgZyYsbEdQTx5bdkMv1+kq7apvUT6Pi2K3c2dFgpiNrCza0ru975gcUhLDszmxQ==",
+      "version": "1.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@arcana/key-helper/-/key-helper-1.0.0-beta.5.tgz",
+      "integrity": "sha512-kYGOV6TXqc9P3p4yXRRRhXkBDx2DMSK1/Xgufl5vxLb0F2lo7dbV6irPllKxfAs9WYE9B1EHPwMciQQrnws9lg==",
       "requires": {
         "bn.js": "^5.2.1",
         "elliptic": "^6.5.4",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@arcana/auth": "^0.1.3",
     "@arcana/auth-core": "^1.0.0-beta.6",
-    "@arcana/key-helper": "^1.0.0-beta.6",
+    "@arcana/key-helper": "^1.0.0-beta.5",
     "@ethereumjs/tx": "^3.4.0",
     "@fontsource/montserrat": "^4.5.14",
     "@fontsource/sora": "^4.5.12",


### PR DESCRIPTION
## Changes

- Downgrade keyhelper to beta.5

## Checklist

- [ ] The branch name follows the format: `developer/AR-XXX-issue-name`.
- [x] The changes have been tested locally.
