### PR TITLE
Update the condition to ignore autofetched nfts

### DIFF
--- a/src/utils/nftUtils.ts
+++ b/src/utils/nftUtils.ts
@@ -164,7 +164,10 @@ async function getDetailedNFTs(nftDB: NFTDB, chainId: number) {
             }),
         getNFTDetails(nft.tokenUrl, nft.tokenId),
       ])
-      if (!ownership?.owner || !details) {
+
+      // Check for undefined because we don't want to remove the NFT if it's autodetected
+      // Ownership is undefined if autodetected
+      if ((ownership !== undefined && !ownership.owner) || !details) {
         nftDB.removeNFT(nft, chainId)
         return
       }


### PR DESCRIPTION
## Changes

- We don't check ownership of NFT if it is autodetected. Added a check to make sure ownership===undefined is not removed from the db.

## Checklist

- [ ] The branch name follows the format: `developer/AR-XXX-issue-name`.
- [x] The changes have been tested locally.
