### PR TITLE
Fix empty personal sign

### DIFF
--- a/src/utils/accountHandler.ts
+++ b/src/utils/accountHandler.ts
@@ -4,7 +4,13 @@ import {
   personalSign,
   signTypedData_v4 as signTypedDataV4,
 } from 'eth-sig-util'
-import { stripHexPrefix, ecsign, setLengthLeft } from 'ethereumjs-util'
+import {
+  isHexString,
+  addHexPrefix,
+  stripHexPrefix,
+  ecsign,
+  setLengthLeft,
+} from 'ethereumjs-util'
 import { ethers } from 'ethers'
 
 import erc1155abi from '@/abis/erc1155.abi.json'
@@ -227,11 +233,14 @@ class AccountHandler {
 
   private async personalSign(address: string, msg: string) {
     try {
+      const msgToSign = isHexString(msg)
+        ? addHexPrefix(msg)
+        : addHexPrefix(Buffer.from(msg).toString('hex'))
       const wallet = this.getWallet(address)
       if (wallet) {
         const signature = personalSign(
           Buffer.from(stripHexPrefix(wallet.privateKey), 'hex'),
-          { data: msg }
+          { data: msgToSign }
         )
         return signature
       } else {

--- a/src/utils/advancedInfo.ts
+++ b/src/utils/advancedInfo.ts
@@ -1,3 +1,5 @@
+import { isHexString } from 'ethereumjs-util'
+
 function isJson(str: string) {
   try {
     JSON.parse(str)
@@ -39,7 +41,7 @@ export const advancedInfo = (method: string, params: string | string[]) => {
       data = params[1]
     }
   } else if (method == 'personal_sign') {
-    data = params[0]
+    data = isHexString(params[0]) ? hex2a(params[0]) : params[0]
   } else if (method == 'eth_signTypedData_v4' && isJson(params[1])) {
     const jsonData = JSON.parse(params[1])
     if (jsonData.domain.name == 'Arcana Forwarder') {


### PR DESCRIPTION
## Changes

- Removed hex2a conversion and showed the raw data passed for personal sign

## Checklist

- [ ] The branch name follows the format: `developer/AR-XXX-issue-name`.
- [x] The changes have been tested locally.
