### PR TITLE
Fix app name size and show assets

### DIFF
--- a/src/components/AssetsView.vue
+++ b/src/components/AssetsView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ethers } from 'ethers'
-import { onMounted, reactive, onBeforeUnmount, ref, watch } from 'vue'
+import { onMounted, onBeforeUnmount, ref, watch, type Ref } from 'vue'
 
 import type { Asset, AssetContract } from '@/models/Asset'
 import AddTokenScreen from '@/pages/AddTokenScreen.vue'
@@ -16,7 +16,7 @@ import { getIconAsset } from '@/utils/useImage'
 
 const userStore = useUserStore()
 const rpcStore = useRpcStore()
-const assets: Asset[] = reactive([])
+const assets: Ref<Asset[]> = ref([])
 const modalStore = useModalStore()
 const showModal = ref(false)
 let assetsPolling
@@ -57,10 +57,10 @@ function fetchNativeAsset() {
 }
 
 async function getAssetsBalance() {
-  const assets = [fetchNativeAsset()]
+  assets.value = [fetchNativeAsset()]
   const storedAssetContracts = fetchStoredAssetContracts()
   storedAssetContracts.forEach((contract) => {
-    assets.push({
+    assets.value.push({
       address: contract.address,
       name: contract.name || contract.symbol,
       symbol: contract.symbol,
@@ -75,7 +75,9 @@ async function getAssetsBalance() {
         walletAddress: userStore.walletAddress,
         contractAddress: contract.address,
       })
-      const asset = assets.find((asset) => asset.address === contract.address)
+      const asset = assets.value.find(
+        (asset) => asset.address === contract.address
+      )
       if (asset) {
         asset.balance = formatTokenDecimals(balance, contract.decimals)
       }
@@ -86,7 +88,7 @@ async function getAssetsBalance() {
 }
 
 function updateAssetsBalance() {
-  assets.forEach(async (asset) => {
+  assets.value.forEach(async (asset) => {
     if (asset.address !== 'native') {
       const balance = await getTokenBalance({
         walletAddress: userStore.walletAddress,

--- a/src/components/WalletHeader.vue
+++ b/src/components/WalletHeader.vue
@@ -66,10 +66,11 @@ watch(
           class="w-xl h-xl"
           onerror="this.style.display='none'"
         />
-        <div class="flex flex-col">
-          <span class="font-bold text-lg max-w-20 overflow-hidde">{{
-            appStore.name
-          }}</span>
+        <div class="flex flex-col items-start">
+          <span
+            class="font-bold text-lg max-w-[200px] overflow-hidden text-ellipsis whitespace-nowrap"
+            >{{ appStore.name }}</span
+          >
           <img
             :src="getImage('secured-by-arcana.svg')"
             class="h-3 select-none"


### PR DESCRIPTION
Resolves [AR-6329](https://team-1624093970686.atlassian.net/browse/AR-6329) and [AR-6374](https://team-1624093970686.atlassian.net/browse/AR-6374).

## Changes

- Shortened name width to max 200px, ellipsis text if it overflows
- Made assets variable reactive so it is updated properly in UI

## Checklist

- [ ] The branch name follows the format: `developer/AR-XXX-issue-name`.
- [x] The changes have been tested locally.


[AR-6329]: https://team-1624093970686.atlassian.net/browse/AR-6329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AR-6374]: https://team-1624093970686.atlassian.net/browse/AR-6374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ