### PR TITLE
[Fix] Removed connecting to parent if logged in on signinv2 page

### DIFF
--- a/src/pages/signInV2.vue
+++ b/src/pages/signInV2.vue
@@ -294,7 +294,6 @@ async function init() {
 
     authProvider = await getAuthProvider(`${appId}`)
     availableLogins.value = await fetchAvailableLogins(authProvider)
-    const parentConnectionInstance = await initializeParentConnection()
 
     // 3PC is disabled or wallet UI cannot store data by a policy decision
     // if (storage.local.storageType === StorageType.IN_MEMORY) {
@@ -324,6 +323,7 @@ async function init() {
       user.hasMfa = hasMfa
       await router.push({ name: 'home' })
     } else {
+      const parentConnectionInstance = await initializeParentConnection()
       const {
         themeConfig: { theme },
         name: appName,


### PR DESCRIPTION
# Pull Request Template

## Changes

- The parent connection should not be created on signIn if already logged in, since it disconnects after

## Checklist

- [ ] The branch name follows the format: `developer/AR-XXX-issue-name`.
- [x] The changes have been tested locally.
