### PR TITLE
Parse the transaction and show actual gas fees

### DIFF
--- a/src/components/GasPrice.vue
+++ b/src/components/GasPrice.vue
@@ -28,14 +28,12 @@ watch(selectedGasMethod, () => {
 })
 
 if (props.maxFeePerGas) {
-  selectedGasMethod.value = 'custom'
   maxFeePerGas.value = new Decimal(props.maxFeePerGas).toNumber()
 } else {
   maxFeePerGas.value = new Decimal(sanitizedBaseFee.value).mul(2).toNumber()
 }
 
 if (props.maxPriorityFeePerGas) {
-  selectedGasMethod.value = 'custom'
   maxPriorityFeePerGas.value = new Decimal(
     props.maxPriorityFeePerGas
   ).toNumber()
@@ -120,7 +118,7 @@ function handleCustomGasPriceInput() {
       </div>
     </div>
   </div>
-  <div v-if="selectedGasMethod === 'custom'" class="flex flex-col gap-4">
+  <div v-if="selectedGasMethod === 'custom'" class="flex flex-col gap-4 mt-4">
     <div class="flex flex-col gap-1">
       <label class="text-sm font-medium" for="gasLimit"> Gas Limit </label>
       <input

--- a/src/components/SkippedRequestView.vue
+++ b/src/components/SkippedRequestView.vue
@@ -56,9 +56,9 @@ watch(
 
 <template>
   <div class="relative card flex flex-col gap-2">
-    <div class="card z-30 relative">
+    <div class="card max-h-[400px] z-30 relative">
       <SendTransaction
-        v-if="isSendTransactionRequest(currentRequest.request.id)"
+        v-if="isSendTransactionRequest(currentRequest?.request.id)"
         :request="currentRequest"
         @gas-price-input="handleGasPriceInput"
         @reject="() => onRejectClick(currentRequest?.request.id)"

--- a/src/components/VJsonViewer.vue
+++ b/src/components/VJsonViewer.vue
@@ -47,9 +47,9 @@ function isString(value: any) {
 
 <template>
   <div class="flex flex-col">
-    <pre v-if="isString(jsonValue)" class="jv-push json-viewer">{{
-      jsonValue
-    }}</pre>
+    <div v-if="isString(jsonValue)" class="jv-string json-viewer">
+      {{ jsonValue }}
+    </div>
     <div v-else class="flex flex-col">
       <div v-for="propKey in propKeys" :key="propKey" class="json-viewer">
         <pre class="jv-key">{{ propKey }}:</pre>

--- a/src/components/VJsonViewer.vue
+++ b/src/components/VJsonViewer.vue
@@ -54,17 +54,15 @@ function isString(value: any) {
       <div v-for="propKey in propKeys" :key="propKey" class="json-viewer">
         <pre class="jv-key">{{ propKey }}:</pre>
         <div v-if="isArray(jsonValue[propKey])" class="flex flex-col">
-          <div
-            v-for="val in jsonValue[propKey]"
-            :key="JSON.stringify(val)"
-            class="ml-4"
-          >
+          <br />
+          <div v-for="val in jsonValue[propKey]" :key="JSON.stringify(val)">
             <pre v-if="isString(val)" class="jv-push">"{{ val }}"</pre>
             <VJsonViewer v-else :value="val" />
           </div>
         </div>
         <div v-else-if="hasObject(jsonValue[propKey])">
-          <div class="ml-4">
+          <br />
+          <div>
             <VJsonViewer :value="jsonValue[propKey]" />
           </div>
         </div>

--- a/src/components/signMessageAdvancedInfo.vue
+++ b/src/components/signMessageAdvancedInfo.vue
@@ -11,14 +11,16 @@ const props = defineProps({
 })
 
 const signInfo = computed(() => {
-  return props.info
+  return props.info as any
 })
 </script>
 
 <template>
   <div
-    class="bg-black-100 p-4 break-word rounded-md overflow-auto max-h-40 break-words"
+    class="bg-black-100 p-4 break-word rounded-md overflow-hidden max-h-40 break-words"
   >
-    <VJsonViewer :value="signInfo"></VJsonViewer>
+    <div class="overflow-auto">
+      <VJsonViewer :value="signInfo"></VJsonViewer>
+    </div>
   </div>
 </template>

--- a/src/components/signMessageAdvancedInfo.vue
+++ b/src/components/signMessageAdvancedInfo.vue
@@ -19,7 +19,7 @@ const signInfo = computed(() => {
   <div
     class="bg-black-100 p-4 break-word rounded-md overflow-hidden max-h-40 break-words"
   >
-    <div class="overflow-auto">
+    <div class="overflow-auto h-full w-full">
       <VJsonViewer :value="signInfo"></VJsonViewer>
     </div>
   </div>

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -65,8 +65,8 @@ export const useAppStore = defineStore('app', {
             ? compactMode
               ? requestStore.pendingRequest?.request.method ===
                 'eth_sendTransaction'
-                ? '328px'
-                : '288px'
+                ? '400px'
+                : '328px'
               : '80vh'
             : '40px'
           : '0'

--- a/src/store/request.ts
+++ b/src/store/request.ts
@@ -75,7 +75,9 @@ export const useRequestStore = defineStore('request', {
       }
     },
     setGasFee(gas: GasFee | null, requestId: string): void {
-      const request = this.pendingRequests[requestId].request
+      const request =
+        this.pendingRequests[requestId]?.request ||
+        this.skippedRequests[requestId]?.request
       if (Array.isArray(request.params)) {
         const param = request.params[0]
         if (param.type && Number(param.type) === 2) {


### PR DESCRIPTION
## Changes

- Parse the `eth_sendTransaction` params and show `from`, `to`, `value` and `data` individually
- Show Transaction Fees in Native currency instead of gas fees in Gwei

## Checklist

- [ ] The branch name follows the format: `developer/AR-XXX-issue-name`.
- [x] The changes have been tested locally.
