### PR TITLE
Significant optimizations and clean-up in the EVM AccountHandler

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Developers can also choose to disable the Arcana Wallet UI and plug in a custom 
 
 This repo contains Aracna Wallet UI implementation. It is a Vue app written in TypeScript and styled with Tailwind CSS.
 
-**Note:**  Arcana Wallet UI is NOT a standalone wallet. It is part of the Arcana Auth SDK.
+**Note:** Arcana Wallet UI is NOT a standalone wallet. It is part of the Arcana Auth SDK.
 
 ## 📋 Installation
 

--- a/src/components/PermissionRequest/SendTransaction.vue
+++ b/src/components/PermissionRequest/SendTransaction.vue
@@ -32,11 +32,11 @@ const showGasFeeLoader = ref(false)
 const showDetails = ref(false)
 
 function calculateValue(value) {
-  return `${new Decimal(value).div(Decimal.pow(10, 18)).toString()}`
+  return new Decimal(value).div(Decimal.pow(10, 18)).toString()
 }
 
 function getGasValue(gasPrice) {
-  return `${new Decimal(gasPrice).add(1.5).mul(21000).toHexadecimal()}`
+  return new Decimal(gasPrice).add(1.5).mul(21000).toHexadecimal()
 }
 
 function calculateGasPrice(gasPrice) {

--- a/src/components/SendNftPreview.vue
+++ b/src/components/SendNftPreview.vue
@@ -9,7 +9,6 @@ import { EVMAccountHandler } from '@/utils/accountHandler'
 import { ChainType } from '@/utils/chainType'
 import { getImage } from '@/utils/getImage'
 import { getRequestHandler } from '@/utils/requestHandlerSingleton'
-import { scwInstance } from '@/utils/scw'
 
 const rpcStore = useRpcStore()
 const appStore = useAppStore()
@@ -20,7 +19,7 @@ const loader = ref({
 })
 const txFees = ref('0')
 
-const paymasterBalance = ref(0)
+const paymasterBalance = ref('0')
 const transactionMode = ref('')
 
 onBeforeMount(async () => {
@@ -29,8 +28,12 @@ onBeforeMount(async () => {
     const requestHandler = getRequestHandler()
     const accountHandler =
       requestHandler.getAccountHandler() as EVMAccountHandler
-    paymasterBalance.value = (await scwInstance.getPaymasterBalance()) / 1e18
-    transactionMode.value = await accountHandler.getTransactionMode()
+    const result =
+      await accountHandler.determineTransactionModeAndPaymasterBalance()
+    paymasterBalance.value = new Decimal(result.paymasterBalance.toHexString())
+      .div(Decimal.pow(10, accountHandler.decimals))
+      .toString()
+    transactionMode.value = result.transactionMode
   }
   loader.value.show = false
 })

--- a/src/components/SendTokensPreview.vue
+++ b/src/components/SendTokensPreview.vue
@@ -11,7 +11,6 @@ import { EVMAccountHandler } from '@/utils/accountHandler'
 import { ChainType } from '@/utils/chainType'
 import { getImage } from '@/utils/getImage'
 import { getRequestHandler } from '@/utils/requestHandlerSingleton'
-import { scwInstance } from '@/utils/scw'
 
 const rpcStore = useRpcStore()
 const appStore = useAppStore()
@@ -33,7 +32,7 @@ const loader = ref({
   message: '',
 })
 
-const paymasterBalance = ref(0)
+const paymasterBalance = ref('0')
 const transactionMode = ref('')
 
 onBeforeMount(async () => {
@@ -41,8 +40,12 @@ onBeforeMount(async () => {
   if (appStore.chainType === ChainType.evm_secp256k1 && rpcStore.useGasless) {
     const accountHandler =
       requestHandler.getAccountHandler() as EVMAccountHandler
-    paymasterBalance.value = (await scwInstance.getPaymasterBalance()) / 1e18
-    transactionMode.value = await accountHandler.getTransactionMode()
+    const result =
+      await accountHandler.determineTransactionModeAndPaymasterBalance()
+    paymasterBalance.value = new Decimal(result.paymasterBalance.toHexString())
+      .div(Decimal.pow(10, accountHandler.decimals))
+      .toString()
+    transactionMode.value = result.transactionMode
   }
   loader.value.show = false
 })

--- a/src/components/SendTransactionCompact.vue
+++ b/src/components/SendTransactionCompact.vue
@@ -13,7 +13,6 @@ import { EVMAccountHandler } from '@/utils/accountHandler'
 import { ChainType } from '@/utils/chainType'
 import { getImage } from '@/utils/getImage'
 import { getRequestHandler } from '@/utils/requestHandlerSingleton'
-import { scwInstance } from '@/utils/scw'
 
 const emits = defineEmits(['reject', 'approve'])
 
@@ -30,7 +29,7 @@ const loader = ref({
   message: '',
 })
 
-const paymasterBalance = ref(0)
+const paymasterBalance = ref('0')
 const transactionMode = ref('')
 
 onBeforeMount(async () => {
@@ -38,8 +37,12 @@ onBeforeMount(async () => {
   if (appStore.chainType === ChainType.evm_secp256k1 && rpcStore.useGasless) {
     const accountHandler =
       requestHandler.getAccountHandler() as EVMAccountHandler
-    paymasterBalance.value = (await scwInstance.getPaymasterBalance()) / 1e18
-    transactionMode.value = await accountHandler.getTransactionMode()
+    const result =
+      await accountHandler.determineTransactionModeAndPaymasterBalance()
+    paymasterBalance.value = new Decimal(result.paymasterBalance.toHexString())
+      .div(Decimal.pow(10, accountHandler.decimals))
+      .toString()
+    transactionMode.value = result.transactionMode
   }
   loader.value.show = false
 })

--- a/src/pages/SendNft.vue
+++ b/src/pages/SendNft.vue
@@ -25,7 +25,6 @@ import { content, errors } from '@/utils/content'
 import { formatTokenDecimals } from '@/utils/formatTokens'
 import { getImage } from '@/utils/getImage'
 import { getRequestHandler } from '@/utils/requestHandlerSingleton'
-import { scwInstance } from '@/utils/scw'
 import { getStorage } from '@/utils/storageWrapper'
 
 type SendNftProps = {
@@ -127,7 +126,7 @@ onMounted(async () => {
   }
 })
 
-const paymasterBalance = ref(0)
+const paymasterBalance = ref('0')
 const transactionMode = ref('')
 
 onBeforeMount(async () => {
@@ -135,8 +134,12 @@ onBeforeMount(async () => {
     const requestHandler = getRequestHandler()
     const accountHandler =
       requestHandler.getAccountHandler() as EVMAccountHandler
-    paymasterBalance.value = (await scwInstance.getPaymasterBalance()) / 1e18
-    transactionMode.value = await accountHandler.getTransactionMode()
+    const result =
+      await accountHandler.determineTransactionModeAndPaymasterBalance()
+    paymasterBalance.value = new Decimal(result.paymasterBalance.toHexString())
+      .div(Decimal.pow(10, accountHandler.decimals))
+      .toString()
+    transactionMode.value = result.transactionMode
   }
 })
 

--- a/src/utils/evm/accountHandler.ts
+++ b/src/utils/evm/accountHandler.ts
@@ -112,7 +112,7 @@ class EVMAccountHandler {
     let mode = ''
     if (paymasterBalance.gt(thresholdPaymasterBalance)) {
       if (isSendIt) {
-        mode = nonce.gt(15) ? 'ARCANA' : ''
+        mode = nonce.lt(15) ? 'ARCANA' : ''
       } else {
         mode = 'SCW'
       }

--- a/src/utils/evm/accountHandler.ts
+++ b/src/utils/evm/accountHandler.ts
@@ -98,11 +98,10 @@ class EVMAccountHandler {
     return appId.length > 0 && SENDIT_APP_ID?.includes(appId)
   }
 
-  public getTransactionMode() {
-    return this.determineScwMode()
-  }
-
-  public async determineScwMode() {
+  public async determineTransactionModeAndPaymasterBalance(): Promise<{
+    paymasterBalance: ethers.BigNumber
+    transactionMode: string
+  }> {
     const [nonce, paymasterBalance] = await Promise.all([
       this.getNonceForArcanaSponsorship(userStore.walletAddress),
       scwInstance.getPaymasterBalance() as Promise<ethers.BigNumber>,
@@ -117,7 +116,15 @@ class EVMAccountHandler {
         mode = 'SCW'
       }
     }
-    return mode
+    return {
+      paymasterBalance,
+      transactionMode: mode,
+    }
+  }
+
+  public async determineScwMode() {
+    return (await this.determineTransactionModeAndPaymasterBalance())
+      .transactionMode
   }
 
   async getNonceForArcanaSponsorship(


### PR DESCRIPTION
# Pull Request Template

Unticketed.

## Blocking dependencies

None.

## Changes

1. Since the `getNonceForArcanaSponsorship` method solely existed to produce a nonce that was always passed to `determineScwMode`, I eliminated it from the latter's callsites and included it inside since there was a parallelization opportunity.
2. There were a few methods where there was a redundant try-catch block (the catch block literally caught the exception and re-threw it by returning a rejected promise via Promise.reject), I removed it. If there is a specific reason why that is a desirable feature, I'll add it back.
3. I found a few places where `getTransactionMode` (which used to call `determineScwMode` which in return calls `getPaymasterBalance`) was being used serially with `getPaymasterBalance`, this is basically calling the same thing twice and waiting twice for the same data. I eliminated this through a minor refactor.
4. Eliminated all usage of the 1e18 literal and replaced them with either Decimal or ethers.BigNumber as appropriate.
5. Eliminated a few usages of the formatting literal without doing any real formatting. 

## Checklist

- [ ] The branch name follows the format: `developer/AR-XXX-issue-name`.
- [x] The changes have been tested locally.
