### PR TITLE
Fix decimal precision and increase default gas limit to 45000 in case of failure to fetch

### DIFF
--- a/src/components/SendTransaction.vue
+++ b/src/components/SendTransaction.vue
@@ -100,7 +100,7 @@ onMounted(async () => {
         })
       ).toString()
     } catch (e) {
-      gasLimit.value = '21000' // default gas limit
+      gasLimit.value = '45000' // max gas limit
     }
     try {
       const baseGasPrice = (
@@ -156,11 +156,13 @@ function handleSetGasPrice(value) {
       maxFeePerGas: value.maxFeePerGas
         ? new Decimal(computeMaxFee(value))
             .mul(Decimal.pow(10, 9))
+            .floor()
             .toHexadecimal()
         : null,
       maxPriorityFeePerGas: value.maxPriorityFeePerGas
         ? new Decimal(value.maxPriorityFeePerGas)
             .mul(Decimal.pow(10, 9))
+            .floor()
             .toHexadecimal()
         : null,
       gasLimit: value.gasLimit ? value.gasLimit : null,
@@ -184,7 +186,8 @@ function calculateGasPrice(params) {
 function getGasValue(params) {
   return new Decimal(params.maxFeePerGas || params.gasPrice)
     .add(params.maxPriorityFeePerGas || 0)
-    .mul(params.gasLimit || params.gas || 21000)
+    .mul(params.gasLimit || params.gas || 45000)
+    .floor()
     .toHexadecimal()
 }
 

--- a/src/pages/PermissionRequest.vue
+++ b/src/pages/PermissionRequest.vue
@@ -344,13 +344,14 @@ async function handleSendToken(params) {
           gas.maxPriorityFeePerGas || 0
         )
         const maxFeeInWei = maxFee.mul(Decimal.pow(10, 9))
-        gasFees = maxFeeInWei.toHexadecimal()
+        gasFees = maxFeeInWei.floor().toHexadecimal()
       }
       if (params.selectedToken === chainConfig.value.currency) {
         const payload: any = {
           to: setHexPrefix(params.recipientWalletAddress),
           value: new Decimal(params.amount)
             .mul(Decimal.pow(10, 18))
+            .floor()
             .toHexadecimal(),
           from: params.senderWalletAddress,
         }
@@ -372,8 +373,9 @@ async function handleSendToken(params) {
         const sendAmount = tokenInfo?.decimals
           ? new Decimal(params.amount)
               .mul(Decimal.pow(10, tokenInfo.decimals))
+              .floor()
               .toHexadecimal()
-          : new Decimal(params.amount).toHexadecimal()
+          : new Decimal(params.amount).floor().toHexadecimal()
         const transactionHash = await accountHandler.sendCustomToken(
           tokenInfo?.address,
           setHexPrefix(params.recipientWalletAddress),

--- a/src/pages/SendNft.vue
+++ b/src/pages/SendNft.vue
@@ -237,7 +237,7 @@ async function handleSendToken() {
           gas.value.maxPriorityFeePerGas || 0
         )
         const maxFeeInWei = maxFee.mul(Decimal.pow(10, 9))
-        gasFees = maxFeeInWei.toHexadecimal()
+        gasFees = maxFeeInWei.floor().toHexadecimal()
       }
 
       const txHash = await accountHandler.sendNft(

--- a/src/pages/SendTokens.vue
+++ b/src/pages/SendTokens.vue
@@ -181,7 +181,7 @@ onMounted(async () => {
               recipientWalletAddress.value
                 ? setHexPrefix(recipientWalletAddress.value)
                 : userStore.walletAddress,
-              new Decimal(Decimal.pow(10, 18)).toHexadecimal()
+              new Decimal(Decimal.pow(10, 18)).floor().toHexadecimal()
             )
           ).toString()
         }
@@ -462,7 +462,7 @@ async function handleEVMSendToken() {
           .mul(Decimal.pow(10, tokenInfo.decimals))
           .floor()
           .toHexadecimal()
-      : new Decimal(amount.value).toHexadecimal()
+      : new Decimal(amount.value).floor().toHexadecimal()
     const transactionHash = await accountHandler.sendCustomToken(
       tokenInfo?.address,
       setHexPrefix(recipientWalletAddress.value),
@@ -611,6 +611,7 @@ async function handleShowPreview() {
               to: setHexPrefix(recipientWalletAddress.value),
               value: new Decimal(amount.value)
                 .mul(Decimal.pow(10, 18))
+                .floor()
                 .toHexadecimal(),
               from: userStore.walletAddress,
             })
@@ -629,7 +630,7 @@ async function handleShowPreview() {
               await accountHandler.estimateCustomTokenGas(
                 tokenInfo?.address,
                 setHexPrefix(recipientWalletAddress.value),
-                new Decimal(sendAmount).toHexadecimal()
+                new Decimal(sendAmount).floor().toHexadecimal()
               )
             ).toString()
           }

--- a/src/pages/TransakSell.vue
+++ b/src/pages/TransakSell.vue
@@ -320,6 +320,7 @@ async function calculateGas() {
             query.value.walletAddress as string,
             new Decimal(query.value.cryptoAmount as string)
               .mul(Decimal.pow(10, selectedCryptoDecimals.value))
+              .floor()
               .toHexadecimal()
           )
         ).toString()
@@ -374,13 +375,16 @@ async function handleApprove() {
       to: setHexPrefix(query.value.walletAddress as string),
       value: new Decimal(query.value.cryptoAmount as string)
         .mul(Decimal.pow(10, 18))
+        .floor()
         .toHexadecimal(),
       from: setHexPrefix(query.value.partnerCustomerId as string),
       maxFeePerGas: new Decimal(gas.maxFee)
         .mul(Decimal.pow(10, 9))
+        .floor()
         .toHexadecimal(),
       maxPriorityFeePerGas: new Decimal(gas.maxPriorityFee)
         .mul(Decimal.pow(10, 9))
+        .floor()
         .toHexadecimal(),
       gasLimit: gas.gasLimit,
     }
@@ -416,13 +420,14 @@ async function handleApprove() {
   } else {
     const amount = new Decimal(query.value.cryptoAmount as string)
       .mul(Decimal.pow(10, selectedCryptoDecimals.value))
+      .floor()
       .toHexadecimal()
     try {
       const txHash = await accountHandler.sendCustomToken(
         contractAddress.value,
         query.value.walletAddress as string,
         amount,
-        new Decimal(gas.maxFee).mul(Decimal.pow(10, 9)).toHexadecimal(),
+        new Decimal(gas.maxFee).mul(Decimal.pow(10, 9)).floor().toHexadecimal(),
         gas.gasLimit
       )
       devLogger.log({ txHash, explorerUrl: explorerUrl.value })

--- a/src/pages/loggedInView.vue
+++ b/src/pages/loggedInView.vue
@@ -365,6 +365,7 @@ async function logout() {
   appStore.showWallet = false
   const authProvider = await getAuthProvider(appStore.id as string)
   await userStore.handleLogout(authProvider)
+  getRequestHandler().onDisconnect()
   router.push(`/${appStore.id}/v2/login?logout=1`)
 }
 
@@ -372,6 +373,7 @@ async function handleLogout() {
   if (parentConnectionStore.parentConnection) {
     const parentConnectionInstance = await parentConnectionStore
       .parentConnection.promise
+    getRequestHandler().onDisconnect()
     const authProvider = await getAuthProvider(appStore.id as string)
     await userStore.handleLogout(authProvider)
     parentConnectionInstance?.onEvent('disconnect')

--- a/src/pages/profileScreen.vue
+++ b/src/pages/profileScreen.vue
@@ -109,6 +109,7 @@ async function handleLogout() {
   appStore.showWallet = false
   const parentConnectionInstance = await parentConnection?.promise
   const authProvider = await getAuthProvider(appId)
+  getRequestHandler().onDisconnect()
   await user.handleLogout(authProvider)
   parentConnectionInstance?.onEvent('disconnect')
 }

--- a/src/utils/evm/accountHandler.ts
+++ b/src/utils/evm/accountHandler.ts
@@ -255,7 +255,7 @@ class EVMAccountHandler {
     }
     if (ercStandard === 'erc1155') {
       const contract = new ethers.Contract(contractAddress, erc1155abi, signer)
-      const hexAmount = new Decimal(amount).toHexadecimal()
+      const hexAmount = new Decimal(amount).floor().toHexadecimal()
       const tx = await contract.safeTransferFrom(
         from,
         to,
@@ -283,7 +283,7 @@ class EVMAccountHandler {
     const signer = this.wallet.connect(this.provider)
     if (ercStandard === 'erc1155') {
       const contract = new ethers.Contract(contractAddress, erc1155abi, signer)
-      const hexAmount = new Decimal(amount).toHexadecimal()
+      const hexAmount = new Decimal(amount).floor().toHexadecimal()
       const gasLimit = await contract.estimateGas.safeTransferFrom(
         from,
         to,

--- a/src/utils/evm/requestHandler.ts
+++ b/src/utils/evm/requestHandler.ts
@@ -51,6 +51,10 @@ class EVMRequestHandler {
     }
   }
 
+  onDisconnect() {
+    this.connectSent = false
+  }
+
   public sendAddressType(addressType: string) {
     this.emitEvent('addressChanged', addressType)
   }

--- a/src/utils/multiversx/requestHandler.ts
+++ b/src/utils/multiversx/requestHandler.ts
@@ -49,6 +49,10 @@ class MultiversXRequestHandler {
     }
   }
 
+  onDisconnect() {
+    this.connectSent = false
+  }
+
   public sendAddressType(addressType: string): Promise<void> {
     return this.emitEvent('addressChanged', addressType)
   }

--- a/src/utils/near/requestHandler.ts
+++ b/src/utils/near/requestHandler.ts
@@ -36,6 +36,10 @@ class NEARRequestHandler {
     // this.emitEvent('chainChanged', { chainId })
   }
 
+  onDisconnect() {
+    this.connectSent = false
+  }
+
   public async sendConnect() {
     if (!this.connectSent) {
       this.connectSent = true

--- a/src/utils/solana/requestHandler.ts
+++ b/src/utils/solana/requestHandler.ts
@@ -24,6 +24,10 @@ class SolanaRequestHandler {
     return ChainType.solana_cv25519
   }
 
+  onDisconnect() {
+    this.connectSent = false
+  }
+
   public async setRpcConfig(c: RpcConfig) {
     await this.accountHandler.setRpcConfig(c)
     this.handler = this.initRpcEngine()


### PR DESCRIPTION
- `floor()` values before converting to hexadecimal to avoid having floating point hexadecimal issues
- Increase default gas limit in case of failures from 21000 to 45000